### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Command | Description
 - `RUSTUP_DIST_ROOT` (default: `https://static.rust-lang.org/dist`)
   Deprecated. Use `RUSTUP_DIST_SERVER` instead.
 
-- `RUSTUP_UPDATE_ROOT` (default `https://static.rust-lang.org/rustup/dist`)
+- `RUSTUP_UPDATE_ROOT` (default `https://static.rust-lang.org/rustup`)
   Sets the root URL for downloading self-updates.
 
 ## Other installation methods


### PR DESCRIPTION
Correct the default value of `RUSTUP_UPDATE_ROOT` which was altered in [this commit](https://github.com/rust-lang-nursery/rustup.rs/commit/09a69e5782273b88dd186016903df727839debc2)
